### PR TITLE
Fixed minor typos in comments

### DIFF
--- a/templates/01_block-scoping.test.js
+++ b/templates/01_block-scoping.test.js
@@ -21,7 +21,7 @@ test('can modify the value of a `let` variable', () => {
   releaseName = 'ES2015'
   // FINAL_END
   // WORKSHOP_START
-  // Delcare 'releaseName' using 'let', setting the value to 'ES6'
+  // Declare 'releaseName' using 'let', setting the value to 'ES6'
   // Change value of releaseName to be `ES2015`, the new name for ES6
   // WORKSHOP_END
   expect(releaseName).toBe('ES2015')

--- a/templates/02_template-literals.test.js
+++ b/templates/02_template-literals.test.js
@@ -48,7 +48,7 @@ test(`should support string escaping`, () => {
   // WORKSHOP_END
 })
 
-// you likely wont often use tagging, but it can be handy!
+// you likely won't often use tagging, but it can be handy!
 test(`should call the tagging function`, () => {
   const noun = 'World'
   const emotion = 'happy'

--- a/templates/14_promises.test.js
+++ b/templates/14_promises.test.js
@@ -95,7 +95,7 @@ function pickApple(ripeness) {
   // Immediately return a promise which will eventually get resolved
   // or rejected by calling the corresponding function.
   return new Promise((resolve, reject) => {
-    // Do something asynchonous. Could be AJAX, using a timeout here.
+    // Do something asynchronous. Could be AJAX, using a timeout here.
     setTimeout(() => {
       if (ripeness === 'ripe') {
         resolve('ripe apple')

--- a/templates/16_es2016.test.js
+++ b/templates/16_es2016.test.js
@@ -18,7 +18,7 @@ test('array.includes can be used to determine whether an item exists in an array
     {name: 'Ingvar Stepanyan'},
   ]
   // WORKSHOP_START
-  // refactor this use `includes` instead
+  // refactor this to use `includes` instead
   const result = greatFriends.indexOf(bestFriend) !== -1
   // WORKSHOP_END
   // FINAL_START

--- a/templates/19_symbols.test.js
+++ b/templates/19_symbols.test.js
@@ -5,7 +5,7 @@ test(`should ensure a variable is unique reference`, () => {
   // FINAL_END
   // WORKSHOP_START
   // The sky's blue and the ocean's blue are both, well, blue.
-  // But the shade of blue changes over time based light and
+  // But the shade of blue changes over time based on light and
   // atmosphere.
   //
   // Let's assume that both the sky's blue and ocean's blue are


### PR DESCRIPTION
I fixed a few typos in comments that I found while taking your workshop at Connect.Tech. I left out the 'const' typo that there is already a PR for. 

If you'd like these in different commits, please let me know, I just didn't want to clutter the history with these sorts of changes.
