### PR TITLE
updates the deprecated 'replace' and 'with' to 'from' and 'to' respectively

### DIFF
--- a/scripts/autofill-feedback-email.js
+++ b/scripts/autofill-feedback-email.js
@@ -9,7 +9,7 @@ if (!email) {
 
 const glob = path.join(__dirname, '..', 'exercises/*.js')
 
-const options = {files: [glob], replace: /&em=/, with: `&em=${email}`}
+const options = {files: [glob], from: /&em=/, to: `&em=${email}`}
 
 replace(options).then(
   changedFiles => {


### PR DESCRIPTION
I got the following error messages when I ran:
yarn run autofill-email YOUR_EMAIL@DOMAIN.COM

Option `replace` is deprecated. Use `from` instead.
Option `with` is deprecated. Use `to` instead.