### PR TITLE
Fix typo, test is checking for ‘six’

### DIFF
--- a/exercises/04_destructure.test.js
+++ b/exercises/04_destructure.test.js
@@ -67,7 +67,7 @@ test('can skip indexes in arrays', () => {
 })
 
 test('can reach nested arrays', () => {
-  // Call getNestedNumbers and pull the first value out as `one`, the 3 as `three` and 6 as `sixth`.
+  // Call getNestedNumbers and pull the first value out as `one`, the 3 as `three` and 6 as `six`.
   expect(one).toBe(1)
   expect(three).toBe(3)
   expect(six).toBe(6)


### PR DESCRIPTION
Instructions say sixth, but the test checks for 'six' :)