### PR TITLE
Fixed Arrow test - can make array filter chains more managable

### DIFF
--- a/exercises-final/09_arrow.test.js
+++ b/exercises-final/09_arrow.test.js
@@ -47,7 +47,7 @@ test('can make array filter chains more managable', () => {
   const shoppingList = data
     .filter(d => d.type != 'Widget') // Remove Widgets
     .filter(d => d.price < 5) // Find only remaining items with price < 5
-    .sort(d => d.qty * -1) // Sort by price, desc
+    .sort(d => d.qty) // Sort by price, asc
     .map(d => d.name) // Pull just the name from each item
 
   expect(shoppingList.shift()).toBe('Bacon')

--- a/templates/09_arrow.test.js
+++ b/templates/09_arrow.test.js
@@ -78,7 +78,7 @@ test('can make array filter chains more managable', () => {
   const shoppingList = data
     .filter(d => d.type != 'Widget') // Remove Widgets
     .filter(d => d.price < 5) // Find only remaining items with price < 5
-    .sort(d => d.qty * -1) // Sort by price, desc
+    .sort(d => d.qty) // Sort by price, asc
     .map(d => d.name) // Pull just the name from each item
   // FINAL_END
   // WORKSHOP_START


### PR DESCRIPTION
Arrow test - can make array filter chains more managable was failing after cloning the repo and running `yarn run setup` and then `git commit -am "setup"`. Just fixed the template.
![image](https://user-images.githubusercontent.com/20327460/48957311-126b9100-ef58-11e8-9b98-2b90591b0fd4.png)
